### PR TITLE
Support Dkan classic drush requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM ubuntu:20.04
+ARG BASE_IMAGE_TAG
 
+FROM ubuntu:${BASE_IMAGE_TAG}
 
+ARG DRUSH_VER
 
 RUN apt-get update
 RUN apt-get install software-properties-common -y
@@ -73,7 +75,7 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV PATH "$PATH:/root/.composer/vendor/bin"
 
 # Install Drush, PHPCS and Drupal Coding Standards
-RUN composer global require drush/drush
+RUN composer global require "drush/drush:$DRUSH_VER"
 RUN composer global require squizlabs/php_codesniffer
 RUN composer global require drupal/coder
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+-include env_make
+
+TAG ?= latest
+UBUNTU_VER ?= 20.04
+
+ifeq ($(TAG), classic)
+        DRUSH_VER = "^8"
+else
+        DRUSH_VER = "^10"
+endif
+
+REPO = getdkan/dkan-cli
+NAME = dkan-cli
+
+.PHONY: build test push shell run start stop logs clean release
+
+default: build
+
+build:
+	docker build -t $(REPO):$(TAG) \
+        --build-arg BASE_IMAGE_TAG=$(UBUNTU_VER) \
+	    --build-arg DRUSH_VER=$(DRUSH_VER) \
+	    ./
+
+test:
+	IMAGE=$(REPO):$(TAG) echo "SKIP"
+
+push:
+	docker push $(REPO):$(TAG)
+
+shell:
+	docker run --rm --name $(NAME) -i -t $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(TAG) /bin/bash
+
+run:
+	docker run --rm --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(TAG) $(CMD)
+
+start:
+	docker run -d --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(TAG)
+
+stop:
+	docker stop $(NAME)
+
+logs:
+	docker logs $(NAME)
+
+clean:
+	-docker rm -f $(NAME)
+
+release: build push

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# DKAN CLI docker container image
+
+## Work with image locally
+Makefile offers handy commands to work with image locally.
+
+### Build
+Build image locally.
+```
+$ make build
+```
+
+To build dkan-cli image suitable for Dkan classic (Drupal 7), set the tag variable to classic
+```
+$ make build TAG=classic
+```
+
+
+### Push
+Push image to registry.
+```
+$ make push
+```
+
+### Shell
+Run a bash shell on an temporary instance of the image.
+```
+$ make shell
+```
+
+### Run
+Run a command on an temporary instance of the image.
+```
+$ make run CMD='echo "hello world"'
+```
+
+### Release (Build + Push)
+Build image locally, then push it to remote registry.
+```
+$ make release
+```
+
+## Build on Docker Hub
+Build Arguments are set using the hooks overrides, documentation available
+[here](https://docs.docker.com/docker-hub/builds/advanced/#override-build-test-or-push-commands).
+
+```
+├── hooks
+│   └── build
+```

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+[ -z "$UBUNTU_VER" ] && UBUNTU_VER=20.04
+
+ # DKAN classic (Drupal 7) only works with drush v8.
+if [[ "$DOCKER_TAG" == "classic" ]]; then
+    DRUSH_VER="^8"
+else
+    DRUSH_VER="^10"
+fi
+
+docker build \
+    --build-arg BASE_IMAGE_TAG="$UBUNTU_VER" \
+    --build-arg DRUSH_VER="$DRUSH_VER" \
+    -f "$DOCKERFILE_PATH" \
+    -t "$IMAGE_NAME" \
+    .


### PR DESCRIPTION
connects NuCivic/dkan_management#338
connects GetDKAN/dkan2#366

1. Add Makefile to document and streamline build process.
2. Add README with documentation.
3. Make base image configurable.
4. Make Drush version configurable.
5. Pin Drush version for `latest` and `classic` docker tags.
6. Add dockerhub hooks to support `classic` docker tag.