### PR TITLE
Support classic (drush v8) vs latest (drush v10) + Rebase ontop of drydockercloud

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,112 +1,61 @@
 ARG BASE_IMAGE_TAG
 
-FROM ubuntu:${BASE_IMAGE_TAG}
+FROM drydockcloud/${BASE_IMAGE_TAG}:latest
 
 ARG DRUSH_VER
 
-RUN apt-get update
-RUN apt-get install software-properties-common -y
-RUN apt-get update
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PHP_INI_SCAN_DIR="/usr/local/php/etc/conf.d"
 
-
-# The basics
-RUN apt-get install -y \
-  supervisor \
-  curl \
-  wget \
-  unzip \
-  locales \
-  git \
-  pv \
-  apt-transport-https \
-  vim \
-  patch \
-  zip
-
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-
-# Cypress.io requirements
-RUN apt update
-RUN DEBIAN_FRONTEND=noninteractive apt install xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 -y
-
-# PHP
-RUN apt update && apt-get update && apt install apache2 -y && \
-    apt install mysql-server -y && \
-    apt-get install -y software-properties-common && \
-    add-apt-repository ppa:ondrej/php && \
-    DEBIAN_FRONTEND=noninteractive apt install php7.3 -y && \
-    DEBIAN_FRONTEND=noninteractive apt install php7.3-dev php7.3-cli php7.3-common php7.3-curl php7.3-gd php7.3-json php7.3-opcache php7.3-mysql php7.3-mbstring php7.3-zip php7.3-xml php7.3-xdebug -y
-
-RUN update-alternatives --set php /usr/bin/php7.3 && \
-    update-alternatives --set phar /usr/bin/phar7.3 && \
-    update-alternatives --set phar.phar /usr/bin/phar.phar7.3 && \
-    update-alternatives --set phpize /usr/bin/phpize7.3 && \
-    update-alternatives --set php-config /usr/bin/php-config7.3
-
-# Disable loading of xdebug.so
-RUN rm -f /etc/php/7.3/cli/conf.d/20-xdebug.ini
-
-# Install AWS CLI
-RUN apt-get install -y awscli
-
-# Install ClamAV
-RUN apt-get install -y clamav
-
-# Install Nodejs and Ruby
-RUN curl -sL https://deb.nodesource.com/setup_13.x | bash
-RUN apt-get install -y nodejs
-
-# Cleanup
-RUN DEBIAN_FRONTEND=noninteractive apt-get clean && \
-	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN \
+  # Add Nodejs source.
+  curl -sL https://deb.nodesource.com/setup_14.x | bash &&\
+  apt-get update &&\
+  # Install basic tools/packages.
+  apt-get install -y apt-transport-https git pv patch vim zip unzip \
+  # Install Cypress.io requirements
+  xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 \
+  # Install AWS CLI.
+  awscli \
+  # Install ClamAV.
+  clamav \
+  # Install Node JS.
+  nodejs &&\
+  # Cleanup.
+  apt-get clean &&\
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install Composer
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php composer-setup.php
-RUN php -r "unlink('composer-setup.php');"
-RUN mv composer.phar /usr/bin/composer
-RUN chmod +x /usr/bin/composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" &&\
+  php composer-setup.php &&\
+  php -r "unlink('composer-setup.php');" &&\
+  mv composer.phar /usr/bin/composer &&\
+  chmod +x /usr/bin/composer
 
 # Allow composer superuser and set environment to use composer executables path
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV PATH "$PATH:/root/.composer/vendor/bin"
 
 # Install Drush, PHPCS and Drupal Coding Standards
-RUN composer global require "drush/drush:$DRUSH_VER"
-RUN composer global require squizlabs/php_codesniffer
-RUN composer global require drupal/coder
+RUN composer global require "drush/drush:$DRUSH_VER" squizlabs/php_codesniffer drupal/coder && \
+  # Set Drupal as default CodeSniffer Standard
+  phpcs --config-set installed_paths /root/.composer/vendor/drupal/coder/coder_sniffer/ &&\
+  phpcs --config-set default_standard Drupal
 
-# Set Drupal as default CodeSniffer Standard
-RUN phpcs --config-set installed_paths /root/.composer/vendor/drupal/coder/coder_sniffer/
-RUN phpcs --config-set default_standard Drupal
-
-# Move .composer to give way to the user's .composer config
+# Move .composer to give way to the user's .composer config. Make sure to
+# update the PATH.
 RUN mv /root/.composer /root/composer
-
-# Add local settings
-COPY php-cli.ini /etc/php/7.3/cli/conf.d/z_php.ini
-
-# Add git completion for the cli
-RUN curl -o ~/.git-completion.bash https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash
-RUN curl -o ~/.git-prompt.sh https://raw.githubusercontent.com/git/git/master/contrib/completion/git-prompt.sh
-COPY bash.rc /root/.bashrc
-
-WORKDIR /var/www
-
-# Add Composer bin directory to PATH
 ENV PATH /root/composer/vendor/bin:$PATH
 
+# Add git completion for the cli
+RUN curl -o ~/.git-completion.bash https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash &&\
+  curl -o ~/.git-prompt.sh https://raw.githubusercontent.com/git/git/master/contrib/completion/git-prompt.sh
+
+# Add local settings
+COPY php-cli.ini /usr/local/php/etc/fpm/conf.d/z_php.ini
+COPY bash.rc /root/.bashrc
 # Startup script
 COPY ./startup.sh /opt/startup.sh
-RUN chmod +x /opt/startup.sh
 
-# Starter script
 ENTRYPOINT ["/opt/startup.sh"]
-
-ENV PHP_INI_SCAN_DIR="/etc/php/7.3/cli/conf.d:/var/www/src/docker/etc/php"
-
-# By default, launch supervisord to keep the container running.
-CMD /usr/bin/supervisord -n
+CMD ["/usr/local/php/sbin/php-fpm"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM ubuntu:20.04
+ARG BASE_IMAGE_TAG
 
+FROM ubuntu:${BASE_IMAGE_TAG}
 
+ARG DRUSH_VER
 
 RUN apt-get update
 RUN apt-get install software-properties-common -y
@@ -73,7 +75,7 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV PATH "$PATH:/root/.composer/vendor/bin"
 
 # Install Drush, PHPCS and Drupal Coding Standards
-RUN composer global require drush/drush
+RUN composer global require "drush/drush:$DRUSH_VER"
 RUN composer global require squizlabs/php_codesniffer
 RUN composer global require drupal/coder
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include env_make
 
 TAG ?= latest
-UBUNTU_VER ?= 20.04
+BASE_IMAGE_TAG ?= drupal-acquia-php-7.3
 
 ifeq ($(TAG), classic)
         DRUSH_VER = "^8"
@@ -17,8 +17,9 @@ NAME = dkan-cli
 default: build
 
 build:
+	echo $(BASE_IMAGE_TAG)
 	docker build -t $(REPO):$(TAG) \
-        --build-arg BASE_IMAGE_TAG=$(UBUNTU_VER) \
+        --build-arg BASE_IMAGE_TAG=$(BASE_IMAGE_TAG) \
 	    --build-arg DRUSH_VER=$(DRUSH_VER) \
 	    ./
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+-include env_make
+
+TAG ?= latest
+UBUNTU_VER ?= 20.04
+
+ifeq ($(TAG), classic)
+        DRUSH_VER = "^8"
+else
+        DRUSH_VER = "^10"
+endif
+
+REPO = getdkan/dkan-cli
+NAME = dkan-cli
+
+.PHONY: build test push shell run start stop logs clean release
+
+default: build
+
+build:
+	docker build -t $(REPO):$(TAG) \
+        --build-arg BASE_IMAGE_TAG=$(UBUNTU_VER) \
+	    --build-arg DRUSH_VER=$(DRUSH_VER) \
+	    ./
+
+test:
+	IMAGE=$(REPO):$(TAG) echo "SKIP"
+
+push:
+	docker push $(REPO):$(TAG)
+
+shell:
+	docker run --rm --name $(NAME) -i -t $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(TAG) /bin/bash
+
+run:
+	docker run --rm --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(TAG) $(CMD)
+
+start:
+	docker run -d --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(TAG)
+
+stop:
+	docker stop $(NAME)
+
+logs:
+	docker logs $(NAME)
+
+clean:
+	-docker rm -f $(NAME)
+
+release: build push

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # DKAN CLI docker container image
 
+## DockerHub Automated Build Config
+DockerHub is configured to build two tags: classic and master:
++ master is for the latest and greatest, drush v10 and should suited to run DKAN2.
++ classic have the latest PHP and tooling, but only drush v8 since it's the upmost version that DKAN-classic supports.
+
+Both docker tags tracks the git master branch. When master is updated, latest
+will be built with drush v10 installed and classic will be built with drush v8
+installed.
+
 ## Work with image locally
 Makefile offers handy commands to work with image locally.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# DKAN CLI docker container image
+
+## Work with image locally
+Makefile offers handy commands to work with image locally.
+
+### Build
+Build image locally.
+```
+$ make build
+```
+
+To build dkan-cli image suitable for Dkan classic (Drupal 7), set the tag variable to classic
+```
+$ make build TAG=classic
+```
+
+
+### Push
+Push image to registry.
+```
+$ make push
+```
+
+### Shell
+Run a bash shell on an temporary instance of the image.
+```
+$ make shell
+```
+
+### Run
+Run a command on an temporary instance of the image.
+```
+$ make run CMD='echo "hello world"'
+```
+
+### Release (Build + Push)
+Build image locally, then push it to remote registry.
+```
+$ make release
+```
+
+## Build on Docker Hub
+Build Arguments are set using the hooks overrides, documentation available
+[here](https://docs.docker.com/docker-hub/builds/advanced/#override-build-test-or-push-commands).
+
+```
+├── hooks
+│   └── build
+```

--- a/hooks/build
+++ b/hooks/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-[ -z "$UBUNTU_VER" ] && UBUNTU_VER=20.04
+[ -z "$BASE_IMAGE_TAG" ] && BASE_IMAGE_TAG=20.04
 
  # DKAN classic (Drupal 7) only works with drush v8.
 if [[ "$DOCKER_TAG" == "classic" ]]; then
@@ -10,7 +10,7 @@ else
 fi
 
 docker build \
-    --build-arg BASE_IMAGE_TAG="$UBUNTU_VER" \
+    --build-arg BASE_IMAGE_TAG="$BASE_IMAGE_TAG" \
     --build-arg DRUSH_VER="$DRUSH_VER" \
     -f "$DOCKERFILE_PATH" \
     -t "$IMAGE_NAME" \

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+[ -z "$UBUNTU_VER" ] && UBUNTU_VER=20.04
+
+ # DKAN classic (Drupal 7) only works with drush v8.
+if [[ "$DOCKER_TAG" == "classic" ]]; then
+    DRUSH_VER="^8"
+else
+    DRUSH_VER="^10"
+fi
+
+docker build \
+    --build-arg BASE_IMAGE_TAG="$UBUNTU_VER" \
+    --build-arg DRUSH_VER="$DRUSH_VER" \
+    -f "$DOCKERFILE_PATH" \
+    -t "$IMAGE_NAME" \
+    .

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -e
 
 # Copy SSH keys from host if available
 # First see if we have a mount at /.ssh
@@ -9,5 +11,5 @@ elif [ -f  /.ssh-b2d/id_rsa ]; then
   cp /.ssh-b2d/id_rsa* ~/.ssh/
 fi
 
-# Execute passed CMD arguments
-exec "$@"
+# Execute passed CMD arguments.
+exec "${@}"


### PR DESCRIPTION
connects NuCivic/dkan_management#338
connects GetDKAN/dkan2#366
connects GetDKAN/dkan#3069

+ Rebase on top of drydockercloud php container.
+ Add Makefile to document and streamline build process.
+ Add README with documentation.
+ Make base image configurable.
+ Make Drush version configurable.
+ Pin Drush version for latest and classic docker tags.
+ Add dockerhub hooks to support classic docker tag.

**Notes**:
Upgraded provided nodejs version to 14.x (LTS), since Node.js 13.x is no longer actively supported.