### PR TITLE
Scan project src folder for PHP .ini files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM drydockcloud/${BASE_IMAGE_TAG}:latest
 ARG DRUSH_VER
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV PHP_INI_SCAN_DIR="/usr/local/php/etc/conf.d"
+ENV PHP_INI_SCAN_DIR="/etc/php/7.2/cli/conf.d:/var/www/src/docker/etc/php"
 
 RUN \
   # Add Nodejs source.


### PR DESCRIPTION
dkan-tools should allow users to add their own php config files in their project _src/docker/etc/php_ folder, primarily to enable and configure xdebug. 

## QA Steps

1. Start with a DKAN project. Kill & remove the CLI container: `dktl dc kill cli && dktl dc rm -f cli` 
2. Clone this repo to a separate local folder, and check out this branch
3. Run `make` from the dkan-cli root folder
4. Return to DKAN project folder. Recreate CLI container: `dktl up -d cli`
5. Run `dktl xdebug:start`
6. Confirm xebug config present: `dktl dc exec cli php -i | grep xdebug` (you should see several dozen results)
7. Try debugging using your normal local process.