### PR TITLE
Add chromium.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN \
   curl -sL https://deb.nodesource.com/setup_14.x | bash &&\
   apt-get update &&\
   # Install basic tools/packages.
-  apt-get install -y apt-transport-https git pv patch vim zip unzip \
+  apt-get install -y apt-transport-https git pv patch vim zip unzip chromium-browser \
   # Install Cypress.io requirements
   xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 \
   # Drush dependencies.


### PR DESCRIPTION
As convenient as using electron is with cypress tests, in some instances a "real" browser does things in a different way that can prevent some errors. 

Specifically our cypress test were suffering from this error: https://stackoverflow.com/questions/59629575/cypress-tests-failing-because-chrome-renderer-is-crashing-in-ci-using-drone. We implemented the solution given in that stackoverflow question, but it was not enough. In other sources it was suggested to use headles chrome or chromium. That solution did work for us.

We generally want to keep this container lean, but due to limitations with cypress we can not use a remote browser: https://github.com/cypress-io/cypress/issues/5984

For now the solution is for us to install chromium for cypress to use.